### PR TITLE
Clean up duplicate dark mode handler

### DIFF
--- a/invoice_visual.py
+++ b/invoice_visual.py
@@ -1753,8 +1753,4 @@ class InvoiceApp(tk.Tk):
 if __name__ == "__main__":
     app = InvoiceApp()
     app.mainloop()
-    def on_toggle_dark_mode(self):
-        """Stub for now, will apply theme next."""
-        # Theme application will be handled in the next step.
-        pass
 


### PR DESCRIPTION
## Summary
- remove stray `on_toggle_dark_mode` definition at end of `invoice_visual.py`
- keep earlier method definition intact

## Testing
- `python -m py_compile invoice_visual.py`


------
https://chatgpt.com/codex/tasks/task_e_684010ba9fb08320a50dd174a8dceeca