### PR TITLE
Fix duplicate header in spec

### DIFF
--- a/invoice_visual.spec
+++ b/invoice_visual.spec
@@ -1,6 +1,5 @@
 # -*- mode: python ; coding: utf-8 -*-
 
-# -*- mode: python ; coding: utf-8 -*-
 import os
 # Use a fixed extraction directory so embedded JSON persists across launches
 runtime_tmpdir = os.path.expanduser(os.path.join("~", ".visual_tmp"))


### PR DESCRIPTION
## Summary
- remove duplicate header line in `invoice_visual.spec`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840114f98f48320ad8b4b1484ee301e